### PR TITLE
Add spatie/image-optimizer as an extra compression step

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		"issues": "https://github.com/axllent/silverstripe-scaled-uploads/issues"
 	},
     "require": {
-		"silverstripe/framework": "^4.0"
+		"silverstripe/framework": "^4.0",
+		"spatie/image-optimizer": "^1.1.4"
 	},
     "autoload": {
         "psr-4": {

--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -5,3 +5,25 @@ composer require axllent/silverstripe-scaled-uploads
 ```
 
 Please refer to the [Configuration.md](Configuration.md) for configuration options.
+
+## Optimization
+
+If you want to make use of the optimization features of this module you'll need to install the following packages on your server environment.
+
+The package will use these optimizers if they are present on your system:
+
+* JpegOptim
+* Optipng
+* Pngquant 2
+* SVGO
+* Gifsicle
+
+Here's how to install all the optimizers on Ubuntu:
+
+```sh
+sudo apt-get install jpegoptim
+sudo apt-get install optipng
+sudo apt-get install pngquant
+sudo npm install -g svgo
+sudo apt-get install gifsicle
+```

--- a/src/ScaledUploads.php
+++ b/src/ScaledUploads.php
@@ -6,6 +6,7 @@ use SilverStripe\Assets\Flysystem\FlysystemAssetStore;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extension;
+use Spatie\ImageOptimizer\OptimizerChainFactory;
 
 /**
  * Automatically scale down uploaded images
@@ -142,6 +143,11 @@ class ScaledUploads extends Extension
             // write to tmp file and then overwrite original
             if ($transformed && $modified) {
                 $transformed->writeTo($tmp_image);
+
+                // Optimize the transformed image
+                $optimizerChain = OptimizerChainFactory::create();
+                $optimizerChain->optimize($tmp_image);
+
                 // if !legacy_filenames then delete original, else rogue copies are left on filesystem
                 if (!Config::inst()->get(FlysystemAssetStore::class, 'legacy_filenames')) {
                     $file->File->deleteFile();


### PR DESCRIPTION
This pr adds an extra compression step after rescaling and rotating. 

The compression is done by the `spatie/image-optimizer` module. The module depends on the JpegOptim, Optipng, Pngquant 2, SVGO and Gifsicle modules for it's optimization. If the modules are not installed the optimization will not be preformed, and will not break execution.